### PR TITLE
Refactor input folder handling to Path

### DIFF
--- a/src/main/java/com/nlstn/jmediaOrganizer/JMediaOrganizer.java
+++ b/src/main/java/com/nlstn/jmediaOrganizer/JMediaOrganizer.java
@@ -1,6 +1,5 @@
 package com.nlstn.jmediaOrganizer;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -56,7 +55,7 @@ public class JMediaOrganizer {
 	/**
 	 * The currently chosen input folder, or null, if no input folder was chosen
 	 */
-	private static File		inputFolder	= null;
+	private static Path		inputFolder	= null;
 
 	public static void main(String[] args) {
 		Settings.loadSettings();
@@ -81,11 +80,11 @@ public class JMediaOrganizer {
 		return window;
 	}
 
-	public static File getInputFolder() {
+	public static Path getInputFolder() {
 		return inputFolder;
 	}
 
-	public static void setInputFolder(File inputFolder) {
+	public static void setInputFolder(Path inputFolder) {
 		JMediaOrganizer.inputFolder = inputFolder;
 	}
 

--- a/src/main/java/com/nlstn/jmediaOrganizer/files/MP3File.java
+++ b/src/main/java/com/nlstn/jmediaOrganizer/files/MP3File.java
@@ -1,6 +1,6 @@
 package com.nlstn.jmediaOrganizer.files;
 
-import java.io.File;
+import java.nio.file.Path;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
@@ -138,7 +138,7 @@ public class MP3File extends MediaFile {
 	 * @param file
 	 *            The mp3 file
 	 */
-	public MP3File(File file) {
+	public MP3File(Path file) {
 		super(file);
 	}
 
@@ -159,10 +159,10 @@ public class MP3File extends MediaFile {
 	 */
 	public boolean loadMp3Data() {
 		try {
-			mp3File = new Mp3File(file);
+			mp3File = new Mp3File(file.toFile());
 		}
 		catch (UnsupportedTagException | InvalidDataException | IOException e) {
-			log.error("Unable to load Mp3 data " + file.getAbsolutePath(), e);
+			log.error("Unable to load Mp3 data " + getAbsolutePath(), e);
 			return false;
 		}
 		return getId3Tags();

--- a/src/main/java/com/nlstn/jmediaOrganizer/files/MediaFile.java
+++ b/src/main/java/com/nlstn/jmediaOrganizer/files/MediaFile.java
@@ -1,7 +1,8 @@
 package com.nlstn.jmediaOrganizer.files;
 
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Locale;
 
@@ -16,102 +17,114 @@ import org.apache.tika.Tika;
  */
 public class MediaFile {
 
-	private static Logger	log;
+        private static Logger   log;
 
-	private static Tika		tika;
+        private static Tika             tika;
 
-	static {
-		log = LogManager.getLogger(MediaFile.class);
-		tika = new Tika();
-	}
+        static {
+                log = LogManager.getLogger(MediaFile.class);
+                tika = new Tika();
+        }
 
-	/**
-	 * The file where this mp3File is stored
-	 */
-	protected File		file;
+        /**
+         * The file where this mp3File is stored
+         */
+        protected Path         file;
 
-	protected String	fileType	= "Undefined";
+        protected String        fileType        = "Undefined";
 
-	public MediaFile(File file) {
-		this.file = file;
-	}
+        public MediaFile(Path file) {
+                this.file = file;
+        }
 
-	public MediaFile() {
+        public MediaFile() {
 
-	}
+        }
 
-	public boolean delete() {
-		if (!file.exists())
-			return true;
-		return file.delete();
-	}
+        public boolean delete() {
+                if (file == null)
+                        return true;
+                try {
+                        return Files.deleteIfExists(file);
+                }
+                catch (IOException e) {
+                        log.error("Failed to delete file {}", getAbsolutePath(), e);
+                        return false;
+                }
+        }
 
-	public String getAbsolutePath() {
-		return file == null ? "" : file.getAbsolutePath();
-	}
+        public String getAbsolutePath() {
+                return file == null ? "" : file.toAbsolutePath().toString();
+        }
 
-	public String getExtension() {
-		if (file == null)
-			return "";
-		return file.getName().substring(file.getName().lastIndexOf('.'));
-	}
+        public String getExtension() {
+                if (file == null)
+                        return "";
+                String name = file.getFileName().toString();
+                int dotIndex = name.lastIndexOf('.');
+                if (dotIndex < 0)
+                        return "";
+                return name.substring(dotIndex);
+        }
 
-	/**
-	 * Goes through the given list of types and checks, whether this file is of any of these types.
-	 * 
-	 * @param types
-	 *            The types to check
-	 * @return Whether the list contains the type of this file.
-	 */
-	public boolean isOfType(List<String> types) {
-		return types.contains(getExtension().toLowerCase(Locale.getDefault()));
-	}
+        /**
+         * Goes through the given list of types and checks, whether this file is of any of these types.
+         *
+         * @param types
+         *            The types to check
+         * @return Whether the list contains the type of this file.
+         */
+        public boolean isOfType(List<String> types) {
+                return types.contains(getExtension().toLowerCase(Locale.getDefault()));
+        }
 
-	/**
-	 * Checks whether this {@link #isOfType(List)} is true, and if so, deletes this file from disc.
-	 * 
-	 * @param types
-	 *            The types to check
-	 * @return Whether or not this file was deleted, based on the outcome of {@link #isOfType(List)} and {@link File#delete()}.
-	 */
-	public boolean deleteIfOfType(List<String> types) {
-		if (types.contains(getExtension().toLowerCase(Locale.getDefault()))) {
-			if (!delete()) {
-				log.error("Failed to delete file " + getAbsolutePath());
-			}
-			else {
-				log.error("Deleting file " + getAbsolutePath());
-			}
-			return true;
-		}
-		return false;
-	}
+        /**
+         * Checks whether this {@link #isOfType(List)} is true, and if so, deletes this file from disc.
+         *
+         * @param types
+         *            The types to check
+         * @return Whether or not this file was deleted, based on the outcome of {@link #isOfType(List)} and {@link java.nio.file.Files#delete(java.nio.file.Path)}.
+         */
+        public boolean deleteIfOfType(List<String> types) {
+                if (types.contains(getExtension().toLowerCase(Locale.getDefault()))) {
+                        if (!delete()) {
+                                log.error("Failed to delete file " + getAbsolutePath());
+                        }
+                        else {
+                                log.error("Deleting file " + getAbsolutePath());
+                        }
+                        return true;
+                }
+                return false;
+        }
 
-	public String determineType() {
-		if (fileType.equals("Undefined") && file != null) {
-			try {
-				fileType = tika.detect(file);
-			}
-			catch (IOException e) {
-				log.error("Error while resolving mime type.", e);
-			}
-		}
-		return fileType;
-	}
+        public String determineType() {
+                if (fileType.equals("Undefined") && file != null) {
+                        try {
+                                fileType = tika.detect(file.toFile());
+                        }
+                        catch (IOException e) {
+                                log.error("Error while resolving mime type.", e);
+                        }
+                }
+                return fileType;
+        }
 
-	protected boolean createNewFile(String newPath) {
-		File f = new File(newPath);
-		File parent = f.getParentFile();
-		if (!parent.mkdirs() && !parent.exists()) {
-			log.error("Failed create parent folder of path {}", newPath);
-			return false;
-		}
-		try {
-			return f.createNewFile() || f.exists();
-		}
-		catch (IOException e) {
-			log.error("Exception while creating new file!", e);
-			return false;
-		}
-	}
+        protected boolean createNewFile(String newPath) {
+                Path target = Path.of(newPath);
+                Path parent = target.getParent();
+                try {
+                        if (parent != null)
+                                Files.createDirectories(parent);
+                        if (Files.exists(target))
+                                return true;
+                        Files.createFile(target);
+                        return true;
+                }
+                catch (IOException e) {
+                        log.error("Exception while creating new file!", e);
+                        return false;
+                }
+        }
 }
+

--- a/src/main/java/com/nlstn/jmediaOrganizer/gui/Window.java
+++ b/src/main/java/com/nlstn/jmediaOrganizer/gui/Window.java
@@ -18,6 +18,8 @@ import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 
 import javax.swing.BorderFactory;
@@ -201,15 +203,16 @@ public class Window {
 		return menuBar;
 	}
 
-	public void onChooseInputFolder() {
-		DirectoryChooser chooser = new DirectoryChooser(frame);
-		File folder = chooser.getSelectedDirectory();
-		if (folder == null)
-			return;
-		JMediaOrganizer.setInputFolder(folder);
-		reloadInputFolder();
-		log.debug("Loaded new folder: " + folder.getAbsolutePath());
-	}
+        public void onChooseInputFolder() {
+                DirectoryChooser chooser = new DirectoryChooser(frame);
+                File folder = chooser.getSelectedDirectory();
+                if (folder == null)
+                        return;
+                Path selected = folder.toPath();
+                JMediaOrganizer.setInputFolder(selected);
+                reloadInputFolder();
+                log.debug("Loaded new folder: " + selected.toAbsolutePath());
+        }
 
 	private void getConversionPreview() {
 		if (!checkInputFolderLoaded())
@@ -229,14 +232,14 @@ public class Window {
 		return true;
 	}
 
-	private void reloadInputFolder() {
-		List<File> files = FileProcessor.loadAllFiles();
-		StringBuilder builder = new StringBuilder();
-		for (File file : files) {
-			builder.append(file.getAbsolutePath()).append("\n");
-		}
-		oldValues.setText(builder.toString());
-	}
+        private void reloadInputFolder() {
+                List<Path> files = FileProcessor.loadAllFiles();
+                StringBuilder builder = new StringBuilder();
+                for (Path file : files) {
+                        builder.append(file.toAbsolutePath()).append("\n");
+                }
+                oldValues.setText(builder.toString());
+        }
 
 	public JFrame getFrame() {
 		return frame;
@@ -294,14 +297,15 @@ public class Window {
 					try {
 						@SuppressWarnings("unchecked")
 						List<File> files = (List<File>) t.getTransferData(flavor);
-						if (files.size() == 1) {
-							if (files.get(0).isDirectory()) {
-								JMediaOrganizer.setInputFolder(files.get(0));
-								reloadInputFolder();
-								log.debug("Loaded folder " + files.get(0).getAbsolutePath() + " per drag and drop");
-								return;
-							}
-						}
+                                                if (files.size() == 1) {
+                                                        Path dropped = files.get(0).toPath();
+                                                        if (Files.isDirectory(dropped)) {
+                                                                JMediaOrganizer.setInputFolder(dropped);
+                                                                reloadInputFolder();
+                                                                log.debug("Loaded folder " + dropped.toAbsolutePath() + " per drag and drop");
+                                                                return;
+                                                        }
+                                                }
 					}
 					catch (UnsupportedFlavorException e1) {
 						log.error("Failed to accept DragAndDrop files.", e1);

--- a/src/main/java/com/nlstn/jmediaOrganizer/processing/callable/ConversionCallable.java
+++ b/src/main/java/com/nlstn/jmediaOrganizer/processing/callable/ConversionCallable.java
@@ -1,6 +1,8 @@
 package com.nlstn.jmediaOrganizer.processing.callable;
 
-import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.concurrent.Callable;
 
@@ -19,10 +21,10 @@ public class ConversionCallable implements Callable<Boolean> {
 
     private static final Logger LOG = LogManager.getLogger(ConversionCallable.class);
 
-    private final List<File> files;
+    private final List<Path> files;
     private final List<String> invalidTypes;
 
-    public ConversionCallable(List<File> files, List<String> invalidTypes) {
+    public ConversionCallable(List<Path> files, List<String> invalidTypes) {
         this.files = List.copyOf(files);
         this.invalidTypes = List.copyOf(invalidTypes);
     }
@@ -30,15 +32,18 @@ public class ConversionCallable implements Callable<Boolean> {
     @Override
     public Boolean call() {
         boolean success = true;
-        for (File file : files) {
+        for (Path file : files) {
             MP3File mp3File = new MP3File(file);
             if (mp3File.deleteIfOfType(invalidTypes)) {
                 continue;
             }
             if (mp3File.loadMp3Data()) {
                 if (mp3File.moveToLocation(Converter.getNewPath(mp3File))) {
-                    if (!file.delete()) {
-                        LOG.warn("Failed to delete relocated file: {}", file.getAbsolutePath());
+                    try {
+                        Files.deleteIfExists(file);
+                    }
+                    catch (IOException e) {
+                        LOG.warn("Failed to delete relocated file: {}", file.toAbsolutePath(), e);
                     }
                 }
                 else {

--- a/src/main/java/com/nlstn/jmediaOrganizer/processing/callable/ConversionPreviewCallable.java
+++ b/src/main/java/com/nlstn/jmediaOrganizer/processing/callable/ConversionPreviewCallable.java
@@ -1,6 +1,6 @@
 package com.nlstn.jmediaOrganizer.processing.callable;
 
-import java.io.File;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Callable;
@@ -11,11 +11,11 @@ import com.nlstn.jmediaOrganizer.processing.Converter;
 
 public class ConversionPreviewCallable implements Callable<List<String>> {
 
-    private final List<File> files;
+    private final List<Path> files;
     private final List<String> invalidTypes;
     private final AtomicInteger progress = new AtomicInteger();
 
-    public ConversionPreviewCallable(List<File> files, List<String> invalidTypes) {
+    public ConversionPreviewCallable(List<Path> files, List<String> invalidTypes) {
         this.files = List.copyOf(files);
         this.invalidTypes = List.copyOf(invalidTypes);
     }
@@ -23,7 +23,7 @@ public class ConversionPreviewCallable implements Callable<List<String>> {
     @Override
     public List<String> call() {
         List<String> result = new ArrayList<>();
-        for (File file : files) {
+        for (Path file : files) {
             MP3File mp3File = new MP3File(file);
             if (!mp3File.isOfType(invalidTypes) && mp3File.loadMp3Data()) {
                 result.add(Converter.getNewPath(mp3File));

--- a/src/main/java/com/nlstn/jmediaOrganizer/properties/LaunchConfiguration.java
+++ b/src/main/java/com/nlstn/jmediaOrganizer/properties/LaunchConfiguration.java
@@ -1,7 +1,9 @@
 package com.nlstn.jmediaOrganizer.properties;
 
-import java.io.File;
 import java.util.Arrays;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
@@ -15,6 +17,7 @@ import org.apache.logging.log4j.Logger;
 
 import com.nlstn.jmediaOrganizer.JMediaOrganizer;
 import com.nlstn.jmediaOrganizer.processing.Pattern;
+import com.nlstn.jmediaOrganizer.properties.Settings;
 
 /**
  * Creation: 23.12.2017
@@ -90,18 +93,18 @@ public class LaunchConfiguration {
 		if (headlessMode) {
 			log.debug("Enabled headlessMode");
 		}
-		if (cmd.hasOption("i")) {
-			String inputFolderString = cmd.getOptionValue("i");
-			File inputFolder = new File(inputFolderString);
-			if (!(inputFolder.exists() && inputFolder.isDirectory())) {
-				log.error("Invalid input folder!");
-				help.printHelp("JMediaOrganizer", options);
-			}
-			else {
-				JMediaOrganizer.setInputFolder(inputFolder);
-				log.debug("Setting {} as the input folder", inputFolder.getAbsolutePath());
-			}
-		}
+                if (cmd.hasOption("i")) {
+                        String inputFolderString = cmd.getOptionValue("i");
+                        Path inputFolder = Paths.get(inputFolderString);
+                        if (!Files.isDirectory(inputFolder)) {
+                                log.error("Invalid input folder!");
+                                help.printHelp("JMediaOrganizer", options);
+                        }
+                        else {
+                                JMediaOrganizer.setInputFolder(inputFolder);
+                                log.debug("Setting {} as the input folder", inputFolder.toAbsolutePath());
+                        }
+                }
 		if (cmd.hasOption("id3")) {
 			Settings.setID3ToNameEnabled(Boolean.valueOf(cmd.getOptionValue("id3")));
 			log.debug("Setting id3ToNameEnabled setting to {}", Boolean.valueOf(cmd.getOptionValue("id3")));
@@ -126,17 +129,17 @@ public class LaunchConfiguration {
 			Settings.setID3ToNamePattern(new Pattern(cmd.getOptionValue("id3p")));
 			log.debug("Setting id3ToNamePattern to {}", cmd.getOptionValue("id3p"));
 		}
-		if (cmd.hasOption("out")) {
-			String outPath = cmd.getOptionValue("out");
-			File outFile = new File(outPath);
-			if (!outFile.isDirectory()) {
-				log.error("Output Folder {} is not a folder!", outFile.getAbsolutePath());
-			}
-			else {
-				Settings.setOutputFolder(outFile.getAbsolutePath());
-				log.debug("Setting outputFolder to {}", outFile.getAbsolutePath());
-			}
-		}
+                if (cmd.hasOption("out")) {
+                        String outPath = cmd.getOptionValue("out");
+                        Path outFile = Paths.get(outPath);
+                        if (!Files.isDirectory(outFile)) {
+                                log.error("Output Folder {} is not a folder!", outFile.toAbsolutePath());
+                        }
+                        else {
+                                Settings.setOutputFolder(outFile.toAbsolutePath().toString());
+                                log.debug("Setting outputFolder to {}", outFile.toAbsolutePath());
+                        }
+                }
 		if (cmd.hasOption("t")) {
 			Settings.setInvalidTypes(Arrays.asList(cmd.getOptionValue("t").split(";")));
 			log.debug("Setting invalidTypes to {}", cmd.getOptionValue("t"));
@@ -147,7 +150,8 @@ public class LaunchConfiguration {
 		return headlessMode;
 	}
 
-	public String getInputFolder() {
-		return cmd.getOptionValue("i");
-	}
+        public Path getInputFolder() {
+                String input = cmd.getOptionValue("i");
+                return input == null ? null : Paths.get(input);
+        }
 }

--- a/src/test/java/com/nlstn/jmediaOrganizer/processing/FileProcessorTest.java
+++ b/src/test/java/com/nlstn/jmediaOrganizer/processing/FileProcessorTest.java
@@ -2,7 +2,6 @@ package com.nlstn.jmediaOrganizer.processing;
 
 import static org.junit.Assert.assertTrue;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -31,7 +30,7 @@ public class FileProcessorTest {
         @Before
         public void setup() throws IOException {
                 inputDirectory = Files.createTempDirectory("jmedia-empty-input");
-                JMediaOrganizer.setInputFolder(inputDirectory.toFile());
+                JMediaOrganizer.setInputFolder(inputDirectory);
                 FileProcessor.loadAllFiles();
         }
 
@@ -41,8 +40,14 @@ public class FileProcessorTest {
                 if (inputDirectory != null) {
                         try (var paths = Files.walk(inputDirectory)) {
                                 paths.sorted(Comparator.reverseOrder())
-                                                .map(Path::toFile)
-                                                .forEach(File::delete);
+                                                .forEach(path -> {
+                                                        try {
+                                                                Files.deleteIfExists(path);
+                                                        }
+                                                        catch (IOException e) {
+                                                                // ignore cleanup failures in tests
+                                                        }
+                                                });
                         }
                 }
         }

--- a/src/test/java/com/nlstn/jmediaOrganizer/test/MainTest.java
+++ b/src/test/java/com/nlstn/jmediaOrganizer/test/MainTest.java
@@ -2,7 +2,7 @@ package com.nlstn.jmediaOrganizer.test;
 
 import static org.junit.Assert.assertEquals;
 
-import java.io.File;
+import java.nio.file.Path;
 import java.util.List;
 
 import com.nlstn.jmediaOrganizer.JMediaOrganizer;
@@ -33,7 +33,7 @@ public class MainTest {
 
 	@Test
 	public void conversionPreviewCountTest() {
-		JMediaOrganizer.setInputFolder(new File("./src/test/resources/ConversionPreviewCountTest"));
+		JMediaOrganizer.setInputFolder(Path.of("./src/test/resources/ConversionPreviewCountTest"));
 		Settings.loadSettings();
 		Settings.setID3ToNameEnabled(true);
 		FileProcessor.loadAllFiles();


### PR DESCRIPTION
## Summary
- change `JMediaOrganizer` and launch configuration parsing to store the input folder as a `Path`
- migrate media processing, GUI interactions, and conversion tasks to use `Path` APIs for traversal and cleanup
- update media abstractions and tests to operate on `Path` values instead of `File`

## Testing
- mvn test *(fails: unable to download plugins from Maven Central due to 403)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690dd3f4b6188328803c67277ba1f401)