### PR TITLE
Switch tests to JUnit 5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,12 +12,24 @@
 		<url>http://github.com/nlstn/JMediaOrganizer/tree/master</url>
 		<tag>HEAD</tag>
 	</scm>
-	<properties>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<java.version>21</java.version>
-		<maven.compiler.source>${java.version}</maven.compiler.source>
-		<maven.compiler.target>${java.version}</maven.compiler.target>
-	</properties>
+        <properties>
+                <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+                <java.version>21</java.version>
+                <maven.compiler.source>${java.version}</maven.compiler.source>
+                <maven.compiler.target>${java.version}</maven.compiler.target>
+        </properties>
+
+        <dependencyManagement>
+                <dependencies>
+                        <dependency>
+                                <groupId>org.junit</groupId>
+                                <artifactId>junit-bom</artifactId>
+                                <version>5.9.3</version>
+                                <type>pom</type>
+                                <scope>import</scope>
+                        </dependency>
+                </dependencies>
+        </dependencyManagement>
 	<dependencies>
 		<dependency>
 			<groupId>com.mpatric</groupId>
@@ -59,19 +71,24 @@
 			<artifactId>commons-io</artifactId>
 			<version>2.20.0</version>
 		</dependency>
-		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<version>4.13.2</version>
-			<scope>test</scope>
-		</dependency>
+                <dependency>
+                        <groupId>org.junit.jupiter</groupId>
+                        <artifactId>junit-jupiter</artifactId>
+                        <scope>test</scope>
+                </dependency>
 		<dependency>
 			<groupId>org.apache.tika</groupId>
 			<artifactId>tika-core</artifactId>
 			<version>3.2.3</version>
 		</dependency>
-	</dependencies>
-	<build>
+        </dependencies>
+        <repositories>
+                <repository>
+                        <id>central</id>
+                        <url>https://repo1.maven.org/maven2</url>
+                </repository>
+        </repositories>
+        <build>
 		<resources>
 			<resource>
 				<directory>src/main/resources</directory>
@@ -87,10 +104,10 @@
 					<target>${java.version}</target>
 				</configuration>
 			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-dependency-plugin</artifactId>
-				<executions>
+                        <plugin>
+                                <groupId>org.apache.maven.plugins</groupId>
+                                <artifactId>maven-dependency-plugin</artifactId>
+                                <executions>
 					<execution>
 						<id>copy-dependencies</id>
 						<phase>prepare-package</phase>
@@ -103,10 +120,10 @@
 					</execution>
 				</executions>
 			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-assembly-plugin</artifactId>
-				<executions>
+                        <plugin>
+                                <groupId>org.apache.maven.plugins</groupId>
+                                <artifactId>maven-assembly-plugin</artifactId>
+                                <executions>
 					<execution>
 						<phase>package</phase>
 						<goals>
@@ -124,7 +141,15 @@
 						</configuration>
 					</execution>
 				</executions>
-			</plugin>
-		</plugins>
-	</build>
+                        </plugin>
+                        <plugin>
+                                <groupId>org.apache.maven.plugins</groupId>
+                                <artifactId>maven-surefire-plugin</artifactId>
+                                <version>3.2.5</version>
+                                <configuration>
+                                        <useModulePath>false</useModulePath>
+                                </configuration>
+                        </plugin>
+                </plugins>
+        </build>
 </project>

--- a/src/test/java/com/nlstn/jmediaOrganizer/HeadlessCliTest.java
+++ b/src/test/java/com/nlstn/jmediaOrganizer/HeadlessCliTest.java
@@ -1,25 +1,23 @@
 package com.nlstn.jmediaOrganizer;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
-public class HeadlessCliTest {
+class HeadlessCliTest {
 
-        @After
-        public void resetFactory() {
+        @AfterEach
+        void resetFactory() {
                 JMediaOrganizer.resetHeadlessHandlerFactory();
         }
 
         @Test
-        public void mainInvokesHeadlessHandlerWhenHeadlessFlagPresent() throws IOException {
-                Path tempDir = Files.createTempDirectory("jmediaOrganizerHeadlessTest");
+        void mainInvokesHeadlessHandlerWhenHeadlessFlagPresent(@TempDir Path tempDir) {
                 AtomicBoolean invoked = new AtomicBoolean(false);
 
                 JMediaOrganizer.setHeadlessHandlerFactory(() -> new HeadlessHandler() {
@@ -29,13 +27,8 @@ public class HeadlessCliTest {
                         }
                 });
 
-                try {
-                        JMediaOrganizer.main(new String[] { "-h", "-i", tempDir.toString() });
-                }
-                finally {
-                        Files.deleteIfExists(tempDir);
-                }
+                JMediaOrganizer.main(new String[] { "-h", "-i", tempDir.toString() });
 
-                assertTrue("Headless handler should be invoked when -h flag is used", invoked.get());
+                assertTrue(invoked.get(), "Headless handler should be invoked when -h flag is used");
         }
 }

--- a/src/test/java/com/nlstn/jmediaOrganizer/processing/FileProcessorTest.java
+++ b/src/test/java/com/nlstn/jmediaOrganizer/processing/FileProcessorTest.java
@@ -1,59 +1,51 @@
 package com.nlstn.jmediaOrganizer.processing;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Comparator;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import com.nlstn.jmediaOrganizer.JMediaOrganizer;
 import com.nlstn.jmediaOrganizer.properties.Settings;
 
-public class FileProcessorTest {
+class FileProcessorTest {
 
-        private Path inputDirectory;
+        @TempDir
+        static Path settingsDirectory;
 
-        @BeforeClass
-        public static void setupSettings() throws IOException {
-                Path settingsDirectory = Files.createTempDirectory("jmedia-settings");
+        @TempDir
+        Path inputDirectory;
+
+        @BeforeAll
+        static void setupSettings() {
                 System.setProperty("jmediaOrganizer.home", settingsDirectory.toString());
                 Settings.loadSettings();
                 Settings.setThreadCount(2);
         }
 
-        @Before
-        public void setup() throws IOException {
-                inputDirectory = Files.createTempDirectory("jmedia-empty-input");
+        @BeforeEach
+        void setup() {
                 JMediaOrganizer.setInputFolder(inputDirectory.toFile());
                 FileProcessor.loadAllFiles();
         }
 
-        @After
-        public void tearDown() throws IOException {
+        @AfterEach
+        void tearDown() {
                 JMediaOrganizer.setInputFolder(null);
-                if (inputDirectory != null) {
-                        try (var paths = Files.walk(inputDirectory)) {
-                                paths.sorted(Comparator.reverseOrder())
-                                                .map(Path::toFile)
-                                                .forEach(File::delete);
-                        }
-                }
         }
 
         @Test
-        public void getConversionPreviewReturnsEmptyListWhenNoFilesPresent() {
+        void getConversionPreviewReturnsEmptyListWhenNoFilesPresent() {
                 assertTrue(FileProcessor.getConversionPreview().isEmpty());
         }
 
         @Test
-        public void convertFilesSucceedsWhenNoFilesPresent() {
+        void convertFilesSucceedsWhenNoFilesPresent() {
                 assertTrue(FileProcessor.convertFiles());
         }
 }

--- a/src/test/java/com/nlstn/jmediaOrganizer/processing/PatternTest.java
+++ b/src/test/java/com/nlstn/jmediaOrganizer/processing/PatternTest.java
@@ -1,18 +1,18 @@
 package com.nlstn.jmediaOrganizer.processing;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class PatternTest {
+class PatternTest {
 
         @Test
-        public void getUsedVariablesFiltersUnknownPlaceholder() {
+        void getUsedVariablesFiltersUnknownPlaceholder() {
                 Pattern pattern = new Pattern("%artist%-%unknown%-%title%");
 
                 List<ConverterVariable> usedVariables = pattern.getUsedVariables();
@@ -26,7 +26,7 @@ public class PatternTest {
         }
 
         @Test
-        public void getUsedVariablesCachesAfterFirstAccess() {
+        void getUsedVariablesCachesAfterFirstAccess() {
                 Pattern pattern = new Pattern("%artist%");
 
                 List<ConverterVariable> firstCall = pattern.getUsedVariables();

--- a/src/test/java/com/nlstn/jmediaOrganizer/properties/ConfigurationHandlerTest.java
+++ b/src/test/java/com/nlstn/jmediaOrganizer/properties/ConfigurationHandlerTest.java
@@ -1,49 +1,46 @@
 package com.nlstn.jmediaOrganizer.properties;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.File;
-import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
-public class ConfigurationHandlerTest {
+class ConfigurationHandlerTest {
 
-        @Rule
-        public TemporaryFolder temporaryFolder = new TemporaryFolder();
+        @TempDir
+        Path temporaryFolder;
 
         private String previousHome;
 
-        @Before
-        public void rememberHomeProperty() {
+        @BeforeEach
+        void rememberHomeProperty() {
                 previousHome = System.getProperty("jmediaOrganizer.home");
         }
 
-        @After
-        public void restoreHomeProperty() {
-                if (previousHome != null)
+        @AfterEach
+        void restoreHomeProperty() {
+                if (previousHome != null) {
                         System.setProperty("jmediaOrganizer.home", previousHome);
-                else
+                } else {
                         System.clearProperty("jmediaOrganizer.home");
+                }
         }
 
         @Test
-        public void loadsConfigurationWhenHomeUsesUnixSeparators() throws IOException {
-                File root = temporaryFolder.getRoot();
-                Path customHome = root.toPath().resolve("config-root/nested");
+        void loadsConfigurationWhenHomeUsesUnixSeparators() {
+                Path customHome = temporaryFolder.resolve("config-root").resolve("nested");
                 System.setProperty("jmediaOrganizer.home", customHome.toString());
 
                 ConfigurationHandler handler = new ConfigurationHandler("settings.config");
 
-                assertNotNull("Configuration should be available", handler.getConfig());
-                assertTrue("Configuration directory should be created", Files.isDirectory(customHome));
-                assertTrue("Configuration file should be copied", Files.exists(customHome.resolve("settings.config")));
+                assertNotNull(handler.getConfig(), "Configuration should be available");
+                assertTrue(Files.isDirectory(customHome), "Configuration directory should be created");
+                assertTrue(Files.exists(customHome.resolve("settings.config")), "Configuration file should be copied");
         }
 }

--- a/src/test/java/com/nlstn/jmediaOrganizer/test/ConverterTest.java
+++ b/src/test/java/com/nlstn/jmediaOrganizer/test/ConverterTest.java
@@ -1,18 +1,18 @@
 package com.nlstn.jmediaOrganizer.test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.nlstn.jmediaOrganizer.files.MP3File;
 import com.nlstn.jmediaOrganizer.processing.Converter;
 import com.nlstn.jmediaOrganizer.processing.Pattern;
 
-public class ConverterTest {
+class ConverterTest {
 
         @Test
-        public void patternPlaceholdersAreReplaced() {
+        void patternPlaceholdersAreReplaced() {
                 MP3File file = new MP3File();
                 file.setArtist("ArtistName");
                 file.setAlbum("AlbumName");
@@ -24,6 +24,6 @@ public class ConverterTest {
                 String result = Converter.getNewPath(file, pattern);
 
                 assertEquals("ArtistName/AlbumName/01 - SongName (ArtistName)", result);
-                assertFalse("Result should not contain unresolved placeholders", result.contains("%"));
+                assertFalse(result.contains("%"), "Result should not contain unresolved placeholders");
         }
 }

--- a/src/test/java/com/nlstn/jmediaOrganizer/test/MainTest.java
+++ b/src/test/java/com/nlstn/jmediaOrganizer/test/MainTest.java
@@ -1,45 +1,45 @@
 package com.nlstn.jmediaOrganizer.test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
 import java.util.List;
 
+import org.junit.jupiter.api.Test;
+
 import com.nlstn.jmediaOrganizer.JMediaOrganizer;
 import com.nlstn.jmediaOrganizer.processing.FileProcessor;
 import com.nlstn.jmediaOrganizer.properties.Settings;
-
-import org.junit.Test;
 
 /**
  * Creation: 7 Jan 2018
  *
  * @author Niklas Lahnstein
  */
-public class MainTest {
+class MainTest {
 
-	@Test
-	public void conversionPreviewSyntaxTest() {
-		// JMediaOrganizer.setInputFolder(new File("./src/test/resources/ConversionPreviewSyntaxTest"));
-		// Settings.loadSettings();
-		// Settings.setID3ToNameEnabled(true);
-		// Settings.setOutputFolder("D:/TestOutput");
-		// Settings.setID3ToNamePattern(new Pattern("%output%/%albumArtist% (%artist%) - %album% (%year%)/%track% - %title% (%bpm%)%extension%"));
-		// FileProcessor.loadAllFiles();
-		// List<String> result = FileProcessor.getConversionPreview();
-		// assertEquals("Conversion Preview result should be D:/TestOutput/A Day to Remember (A Day to Remember) - And Their Name Was Treason (2005)/9 - 1958 (-1).mp3!", "D:/TestOutput/A Day to Remember (A Day to Remember) - And Their Name Was Treason (2005)/9 - 1958 (-1).mp3", result.get(0));
-		// FileProcessor.clearCurrentFiles();
-	}
+        @Test
+        void conversionPreviewSyntaxTest() {
+                // JMediaOrganizer.setInputFolder(new File("./src/test/resources/ConversionPreviewSyntaxTest"));
+                // Settings.loadSettings();
+                // Settings.setID3ToNameEnabled(true);
+                // Settings.setOutputFolder("D:/TestOutput");
+                // Settings.setID3ToNamePattern(new Pattern("%output%/%albumArtist% (%artist%) - %album% (%year%)/%track% - %title% (%bpm%)%extension%"));
+                // FileProcessor.loadAllFiles();
+                // List<String> result = FileProcessor.getConversionPreview();
+                // assertEquals("Conversion Preview result should be D:/TestOutput/A Day to Remember (A Day to Remember) - And Their Name Was Treason (2005)/9 - 1958 (-1).mp3!", "D:/TestOutput/A Day to Remember (A Day to Remember) - And Their Name Was Treason (2005)/9 - 1958 (-1).mp3", result.get(0));
+                // FileProcessor.clearCurrentFiles();
+        }
 
-	@Test
-	public void conversionPreviewCountTest() {
-		JMediaOrganizer.setInputFolder(new File("./src/test/resources/ConversionPreviewCountTest"));
-		Settings.loadSettings();
-		Settings.setID3ToNameEnabled(true);
-		FileProcessor.loadAllFiles();
-		List<String> result = FileProcessor.getConversionPreview();
-		assertEquals("Conversion Preview count should be 14", 14, result.size());
-		FileProcessor.clearCurrentFiles();
-	}
+        @Test
+        void conversionPreviewCountTest() {
+                JMediaOrganizer.setInputFolder(new File("./src/test/resources/ConversionPreviewCountTest"));
+                Settings.loadSettings();
+                Settings.setID3ToNameEnabled(true);
+                FileProcessor.loadAllFiles();
+                List<String> result = FileProcessor.getConversionPreview();
+                assertEquals("Conversion Preview count should be 14", 14, result.size());
+                FileProcessor.clearCurrentFiles();
+        }
 
 }


### PR DESCRIPTION
## Summary
- replace the legacy JUnit 4 dependency with the JUnit Jupiter BOM and enable the Maven Surefire plugin for the JUnit Platform
- migrate all unit tests to the org.junit.jupiter.api API, updating lifecycle hooks and assertions
- refresh temporary-directory handling in tests to rely on @TempDir and simplify cleanup logic

## Testing
- mvn test *(fails: unable to download JUnit artifacts in the sandboxed environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690dd3f7571c83289dca389c1ebd2f17)