### PR TITLE
Use static final loggers

### DIFF
--- a/src/main/java/com/nlstn/jmediaOrganizer/HeadlessHandler.java
+++ b/src/main/java/com/nlstn/jmediaOrganizer/HeadlessHandler.java
@@ -12,14 +12,10 @@ import com.nlstn.jmediaOrganizer.processing.FileProcessor;
  */
 public class HeadlessHandler {
 
-	private static Logger log;
-
-	static {
-		log = LogManager.getLogger(HeadlessHandler.class);
-	}
+        private static final Logger LOGGER = LogManager.getLogger(HeadlessHandler.class);
 
 	public HeadlessHandler() {
-		log.info("Launching Headless Mode");
+                LOGGER.info("Launching Headless Mode");
 		run();
 	}
 

--- a/src/main/java/com/nlstn/jmediaOrganizer/JMediaOrganizer.java
+++ b/src/main/java/com/nlstn/jmediaOrganizer/JMediaOrganizer.java
@@ -24,7 +24,7 @@ import com.nlstn.jmediaOrganizer.properties.Settings;
  */
 public class JMediaOrganizer {
 
-	private static Logger log;
+        private static final Logger LOGGER = LogManager.getLogger(JMediaOrganizer.class);
 
         static {
                 Path configuredHome;
@@ -44,7 +44,6 @@ public class JMediaOrganizer {
                 }
 
                 System.setProperty("jmediaOrganizer.home", absoluteHome.toString());
-                log = LogManager.getLogger(JMediaOrganizer.class);
         }
 
 	/**
@@ -62,7 +61,7 @@ public class JMediaOrganizer {
 		Settings.loadSettings();
 		ProjectProperties.loadProjectProperties();
 		LaunchConfiguration config = LaunchConfiguration.parse(args);
-		log.info("Starting " + ProjectProperties.getName() + " v" + ProjectProperties.getVersion());
+                LOGGER.info("Starting " + ProjectProperties.getName() + " v" + ProjectProperties.getVersion());
 		if (config.isHeadlessModeEnabled())
 			headlessHandlerFactory.get();
 		else

--- a/src/main/java/com/nlstn/jmediaOrganizer/files/MP3File.java
+++ b/src/main/java/com/nlstn/jmediaOrganizer/files/MP3File.java
@@ -26,11 +26,7 @@ import com.mpatric.mp3agic.UnsupportedTagException;
  */
 public class MP3File extends MediaFile {
 
-	private static Logger log;
-
-	static {
-		log = LogManager.getLogger(MP3File.class);
-	}
+	private static final Logger LOGGER = LogManager.getLogger(MP3File.class);
 
 	/**
 	 * Mapping between the byte representation and the display name of genres, copied from http://id3.org/d3v2.3.0?highlight=(id3v2.3.0.txt)
@@ -162,7 +158,7 @@ public class MP3File extends MediaFile {
 			mp3File = new Mp3File(file);
 		}
 		catch (UnsupportedTagException | InvalidDataException | IOException e) {
-			log.error("Unable to load Mp3 data " + file.getAbsolutePath(), e);
+			LOGGER.error("Unable to load Mp3 data " + file.getAbsolutePath(), e);
 			return false;
 		}
 		return getId3Tags();
@@ -189,13 +185,13 @@ public class MP3File extends MediaFile {
 				mp3File.save(newLocation);
 			}
 			catch (NotSupportedException | IOException e2) {
-				log.error("Failed to relocate file", e2);
+				LOGGER.error("Failed to relocate file", e2);
 				return false;
 			}
 			return true;
 		}
 		catch (IOException e) {
-			log.error("Failed to relocate file", e);
+			LOGGER.error("Failed to relocate file", e);
 			return false;
 		}
 	}
@@ -228,22 +224,22 @@ public class MP3File extends MediaFile {
 				id3Tag = copyID3ToID3v2(mp3File.getId3v1Tag());
 				mp3File.removeId3v1Tag();
 				mp3File.setId3v2Tag(id3Tag);
-				log.info("Fixed outdated ID3Tags!");
+				LOGGER.info("Fixed outdated ID3Tags!");
 			}
 			else {
-				log.error("Missing ID3Tags " + getAbsolutePath());
+				LOGGER.error("Missing ID3Tags " + getAbsolutePath());
 				return false;
 			}
 		if (id3Tag.getArtist() == null && id3Tag.getAlbumArtist() != null) {
 			id3Tag.setArtist(id3Tag.getAlbumArtist());
-			log.debug("Filling empty Artist with Album Artist");
+			LOGGER.debug("Filling empty Artist with Album Artist");
 		}
 		if (id3Tag.getArtist() != null && id3Tag.getAlbumArtist() == null) {
 			id3Tag.setAlbumArtist(id3Tag.getArtist());
-			log.debug("Filling empty Album Artist with Artist!");
+			LOGGER.debug("Filling empty Album Artist with Artist!");
 		}
 		if (id3Tag.getArtist() == null || id3Tag.getArtist().equals("") || id3Tag.getAlbum() == null || id3Tag.getAlbum().equals("") || id3Tag.getTitle() == null || id3Tag.getTitle().equals("") || id3Tag.getTrack() == null || id3Tag.getTrack().equals("")) {
-			log.error("Missing ID3Tags " + getAbsolutePath());
+			LOGGER.error("Missing ID3Tags " + getAbsolutePath());
 			return false;
 		}
 		return true;

--- a/src/main/java/com/nlstn/jmediaOrganizer/files/MediaFile.java
+++ b/src/main/java/com/nlstn/jmediaOrganizer/files/MediaFile.java
@@ -16,14 +16,9 @@ import org.apache.tika.Tika;
  */
 public class MediaFile {
 
-	private static Logger	log;
+	private static final Logger LOGGER = LogManager.getLogger(MediaFile.class);
 
-	private static Tika		tika;
-
-	static {
-		log = LogManager.getLogger(MediaFile.class);
-		tika = new Tika();
-	}
+	private static final Tika TIKA = new Tika();
 
 	/**
 	 * The file where this mp3File is stored
@@ -77,10 +72,10 @@ public class MediaFile {
 	public boolean deleteIfOfType(List<String> types) {
 		if (types.contains(getExtension().toLowerCase(Locale.getDefault()))) {
 			if (!delete()) {
-				log.error("Failed to delete file " + getAbsolutePath());
+				LOGGER.error("Failed to delete file " + getAbsolutePath());
 			}
 			else {
-				log.error("Deleting file " + getAbsolutePath());
+				LOGGER.error("Deleting file " + getAbsolutePath());
 			}
 			return true;
 		}
@@ -90,10 +85,10 @@ public class MediaFile {
 	public String determineType() {
 		if (fileType.equals("Undefined") && file != null) {
 			try {
-				fileType = tika.detect(file);
+				fileType = TIKA.detect(file);
 			}
 			catch (IOException e) {
-				log.error("Error while resolving mime type.", e);
+				LOGGER.error("Error while resolving mime type.", e);
 			}
 		}
 		return fileType;
@@ -103,14 +98,14 @@ public class MediaFile {
 		File f = new File(newPath);
 		File parent = f.getParentFile();
 		if (!parent.mkdirs() && !parent.exists()) {
-			log.error("Failed create parent folder of path {}", newPath);
+			LOGGER.error("Failed create parent folder of path {}", newPath);
 			return false;
 		}
 		try {
 			return f.createNewFile() || f.exists();
 		}
 		catch (IOException e) {
-			log.error("Exception while creating new file!", e);
+			LOGGER.error("Exception while creating new file!", e);
 			return false;
 		}
 	}

--- a/src/main/java/com/nlstn/jmediaOrganizer/gui/Window.java
+++ b/src/main/java/com/nlstn/jmediaOrganizer/gui/Window.java
@@ -58,11 +58,7 @@ import com.nlstn.jmediaOrganizer.properties.ProjectProperties;
  */
 public class Window {
 
-	private static Logger log;
-
-	static {
-		log = LogManager.getLogger(Window.class);
-	}
+	private static final Logger LOGGER = LogManager.getLogger(Window.class);
 
 	public static final int	BUTTON_WIDTH	= 150;
 
@@ -83,12 +79,12 @@ public class Window {
 	private JTextArea		newValues;
 
 	public Window() {
-		log.debug("Creating main window...");
+		LOGGER.debug("Creating main window...");
 		try {
 			UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
 		}
 		catch (ClassNotFoundException | InstantiationException | IllegalAccessException | UnsupportedLookAndFeelException e) {
-			log.error("Failed to set Look and Feel!", e);
+			LOGGER.error("Failed to set Look and Feel!", e);
 		}
 		frame = new JFrame(ProjectProperties.getName());
 		frame.setSize(width, height);
@@ -137,7 +133,7 @@ public class Window {
 		new DropTarget(newValues, listener);
 
 		frame.setVisible(true);
-		log.debug("Finished building window.");
+		LOGGER.debug("Finished building window.");
 	}
 
 	/**
@@ -208,7 +204,7 @@ public class Window {
 			return;
 		JMediaOrganizer.setInputFolder(folder);
 		reloadInputFolder();
-		log.debug("Loaded new folder: " + folder.getAbsolutePath());
+		LOGGER.debug("Loaded new folder: " + folder.getAbsolutePath());
 	}
 
 	private void getConversionPreview() {
@@ -298,16 +294,16 @@ public class Window {
 							if (files.get(0).isDirectory()) {
 								JMediaOrganizer.setInputFolder(files.get(0));
 								reloadInputFolder();
-								log.debug("Loaded folder " + files.get(0).getAbsolutePath() + " per drag and drop");
+								LOGGER.debug("Loaded folder " + files.get(0).getAbsolutePath() + " per drag and drop");
 								return;
 							}
 						}
 					}
 					catch (UnsupportedFlavorException e1) {
-						log.error("Failed to accept DragAndDrop files.", e1);
+						LOGGER.error("Failed to accept DragAndDrop files.", e1);
 					}
 					catch (IOException e1) {
-						log.error("Failed to accept DragAndDrop files.", e1);
+						LOGGER.error("Failed to accept DragAndDrop files.", e1);
 					}
 				}
 			}

--- a/src/main/java/com/nlstn/jmediaOrganizer/properties/ConfigurationHandler.java
+++ b/src/main/java/com/nlstn/jmediaOrganizer/properties/ConfigurationHandler.java
@@ -25,13 +25,8 @@ import org.apache.logging.log4j.Logger;
  */
 public class ConfigurationHandler {
 
-	private static Logger			log;
-	private static Configurations	configs;
-
-	static {
-		log = LogManager.getLogger(ConfigurationHandler.class);
-		configs = new Configurations();
-	}
+	private static final Logger LOGGER = LogManager.getLogger(ConfigurationHandler.class);
+	private static final Configurations configs = new Configurations();
 
 	private FileBasedConfigurationBuilder<XMLConfiguration>	builder;
 	private FileBasedConfiguration							config;
@@ -46,7 +41,7 @@ public class ConfigurationHandler {
                         Files.createDirectories(configurationDirectory);
                 }
                 catch (IOException e) {
-                        log.error("Failed to create configuration directory {}", configurationDirectory, e);
+                        LOGGER.error("Failed to create configuration directory {}", configurationDirectory, e);
                         throw new IllegalStateException(
                                         "Unable to create configuration directory " + configurationDirectory, e);
                 }
@@ -62,7 +57,7 @@ public class ConfigurationHandler {
 			config = builder.getConfiguration();
 		}
 		catch (ConfigurationException e) {
-			log.error("Failed to create configuration!", e);
+			LOGGER.error("Failed to create configuration!", e);
 		}
 	}
 
@@ -75,7 +70,7 @@ public class ConfigurationHandler {
 			builder.save();
 		}
 		catch (ConfigurationException e) {
-			log.error("Failed to save configuration!", e);
+			LOGGER.error("Failed to save configuration!", e);
 		}
 	}
 
@@ -89,7 +84,7 @@ public class ConfigurationHandler {
                         Files.copy(exampleFile, propertiesPath);
                 }
                 catch (IOException e) {
-                        log.error("Failed to copy sample settings file!", e);
+                        LOGGER.error("Failed to copy sample settings file!", e);
                         throw new IllegalStateException("Unable to copy sample settings file to " + propertiesPath, e);
                 }
         }

--- a/src/main/java/com/nlstn/jmediaOrganizer/properties/LaunchConfiguration.java
+++ b/src/main/java/com/nlstn/jmediaOrganizer/properties/LaunchConfiguration.java
@@ -23,11 +23,7 @@ import com.nlstn.jmediaOrganizer.processing.Pattern;
  */
 public class LaunchConfiguration {
 
-	private static Logger log;
-
-	static {
-		log = LogManager.getLogger(LaunchConfiguration.class);
-	}
+        private static final Logger LOGGER = LogManager.getLogger(LaunchConfiguration.class);
 
 	public static LaunchConfiguration parse(String[] args) {
 		return new LaunchConfiguration(args);
@@ -39,7 +35,7 @@ public class LaunchConfiguration {
 	private boolean		headlessMode;
 
 	private LaunchConfiguration(String[] args) {
-		log.trace("Building CommandLineParser");
+                LOGGER.trace("Building CommandLineParser");
 		options = new Options();
 
 		Option headless = Option.builder("h").desc("Run in headless mode").longOpt("headless").build();
@@ -88,58 +84,58 @@ public class LaunchConfiguration {
 			Runtime.getRuntime().exit(-1);
 		}
 		if (headlessMode) {
-			log.debug("Enabled headlessMode");
+                        LOGGER.debug("Enabled headlessMode");
 		}
 		if (cmd.hasOption("i")) {
 			String inputFolderString = cmd.getOptionValue("i");
 			File inputFolder = new File(inputFolderString);
 			if (!(inputFolder.exists() && inputFolder.isDirectory())) {
-				log.error("Invalid input folder!");
+                                LOGGER.error("Invalid input folder!");
 				help.printHelp("JMediaOrganizer", options);
 			}
 			else {
 				JMediaOrganizer.setInputFolder(inputFolder);
-				log.debug("Setting {} as the input folder", inputFolder.getAbsolutePath());
+                                LOGGER.debug("Setting {} as the input folder", inputFolder.getAbsolutePath());
 			}
 		}
 		if (cmd.hasOption("id3")) {
 			Settings.setID3ToNameEnabled(Boolean.valueOf(cmd.getOptionValue("id3")));
-			log.debug("Setting id3ToNameEnabled setting to {}", Boolean.valueOf(cmd.getOptionValue("id3")));
+                        LOGGER.debug("Setting id3ToNameEnabled setting to {}", Boolean.valueOf(cmd.getOptionValue("id3")));
 		}
 		if (cmd.hasOption("tc")) {
 			try {
 				int threadCount = Integer.parseInt(cmd.getOptionValue("tc"));
 				int cores = Runtime.getRuntime().availableProcessors();
 				if (threadCount <= 0 || threadCount > cores) {
-					log.error("Invalid thread count! {}", threadCount);
+                                        LOGGER.error("Invalid thread count! {}", threadCount);
 				}
 				else {
 					Settings.setThreadCount(threadCount);
-					log.debug("Setting threadCount to {}", threadCount);
+                                        LOGGER.debug("Setting threadCount to {}", threadCount);
 				}
 			}
 			catch (NumberFormatException e) {
-				log.error("Threadcount must be a number! {}", cmd.getOptionValue("tc"));
+                                LOGGER.error("Threadcount must be a number! {}", cmd.getOptionValue("tc"));
 			}
 		}
 		if (cmd.hasOption("id3p")) {
 			Settings.setID3ToNamePattern(new Pattern(cmd.getOptionValue("id3p")));
-			log.debug("Setting id3ToNamePattern to {}", cmd.getOptionValue("id3p"));
+                        LOGGER.debug("Setting id3ToNamePattern to {}", cmd.getOptionValue("id3p"));
 		}
 		if (cmd.hasOption("out")) {
 			String outPath = cmd.getOptionValue("out");
 			File outFile = new File(outPath);
 			if (!outFile.isDirectory()) {
-				log.error("Output Folder {} is not a folder!", outFile.getAbsolutePath());
+                                LOGGER.error("Output Folder {} is not a folder!", outFile.getAbsolutePath());
 			}
 			else {
 				Settings.setOutputFolder(outFile.getAbsolutePath());
-				log.debug("Setting outputFolder to {}", outFile.getAbsolutePath());
+                                LOGGER.debug("Setting outputFolder to {}", outFile.getAbsolutePath());
 			}
 		}
 		if (cmd.hasOption("t")) {
 			Settings.setInvalidTypes(Arrays.asList(cmd.getOptionValue("t").split(";")));
-			log.debug("Setting invalidTypes to {}", cmd.getOptionValue("t"));
+                        LOGGER.debug("Setting invalidTypes to {}", cmd.getOptionValue("t"));
 		}
 	}
 


### PR DESCRIPTION
## Summary
- replace mutable static logger fields with static final constants across the main application classes
- remove the redundant static initializer blocks that only created the loggers and adjust call sites to use the new constants
- eagerly initialize related static helpers where needed so configuration loading still works without deferred logger setup

## Testing
- `mvn -q -DskipTests package` *(fails: unable to download maven-resources-plugin because of 403 from repo.maven.apache.org)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690dd3fc15988328bc08309f46ca44ca)