### PR TITLE
Handle CLI errors with exceptions

### DIFF
--- a/src/main/java/com/nlstn/jmediaOrganizer/JMediaOrganizer.java
+++ b/src/main/java/com/nlstn/jmediaOrganizer/JMediaOrganizer.java
@@ -11,6 +11,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import com.nlstn.jmediaOrganizer.gui.Window;
+import com.nlstn.jmediaOrganizer.properties.InvalidLaunchConfigurationException;
 import com.nlstn.jmediaOrganizer.properties.LaunchConfiguration;
 import com.nlstn.jmediaOrganizer.properties.ProjectProperties;
 import com.nlstn.jmediaOrganizer.properties.Settings;
@@ -59,15 +60,26 @@ public class JMediaOrganizer {
 	private static File		inputFolder	= null;
 
 	public static void main(String[] args) {
-		Settings.loadSettings();
-		ProjectProperties.loadProjectProperties();
-		LaunchConfiguration config = LaunchConfiguration.parse(args);
-		log.info("Starting " + ProjectProperties.getName() + " v" + ProjectProperties.getVersion());
-		if (config.isHeadlessModeEnabled())
-			headlessHandlerFactory.get();
-		else
-			window = new Window();
-	}
+                Settings.loadSettings();
+                ProjectProperties.loadProjectProperties();
+                try {
+                        LaunchConfiguration config = LaunchConfiguration.parse(args);
+                        log.info("Starting " + ProjectProperties.getName() + " v" + ProjectProperties.getVersion());
+                        if (config.isHeadlessModeEnabled())
+                                headlessHandlerFactory.get();
+                        else
+                                window = new Window();
+                }
+                catch (InvalidLaunchConfigurationException e) {
+                        log.error(e.getMessage());
+                        System.err.println(e.getMessage());
+                        String helpText = e.getHelpText();
+                        if (helpText != null && !helpText.isBlank()) {
+                                System.err.println(helpText);
+                        }
+                        System.exit(1);
+                }
+        }
 
 	static void setHeadlessHandlerFactory(Supplier<HeadlessHandler> factory) {
 		headlessHandlerFactory = factory == null ? HeadlessHandler::new : factory;

--- a/src/main/java/com/nlstn/jmediaOrganizer/properties/InvalidLaunchConfigurationException.java
+++ b/src/main/java/com/nlstn/jmediaOrganizer/properties/InvalidLaunchConfigurationException.java
@@ -1,0 +1,25 @@
+package com.nlstn.jmediaOrganizer.properties;
+
+/**
+ * Exception representing invalid launch configuration arguments.
+ */
+public class InvalidLaunchConfigurationException extends IllegalArgumentException {
+
+        private static final long serialVersionUID = 1L;
+
+        private final String helpText;
+
+        public InvalidLaunchConfigurationException(String message, String helpText) {
+                super(message);
+                this.helpText = helpText;
+        }
+
+        public InvalidLaunchConfigurationException(String message, String helpText, Throwable cause) {
+                super(message, cause);
+                this.helpText = helpText;
+        }
+
+        public String getHelpText() {
+                return helpText;
+        }
+}

--- a/src/test/java/com/nlstn/jmediaOrganizer/properties/LaunchConfigurationTest.java
+++ b/src/test/java/com/nlstn/jmediaOrganizer/properties/LaunchConfigurationTest.java
@@ -1,0 +1,33 @@
+package com.nlstn.jmediaOrganizer.properties;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class LaunchConfigurationTest {
+
+        @Test
+        public void parseThrowsWhenHeadlessInputMissing() {
+                InvalidLaunchConfigurationException exception = assertThrows(
+                                InvalidLaunchConfigurationException.class,
+                                () -> LaunchConfiguration.parse(new String[] { "-h" }));
+
+                assertTrue(exception.getMessage().contains("input folder"));
+                assertNotNull(exception.getHelpText());
+                assertFalse(exception.getHelpText().isBlank());
+        }
+
+        @Test
+        public void parseThrowsWhenUnknownOptionSupplied() {
+                InvalidLaunchConfigurationException exception = assertThrows(
+                                InvalidLaunchConfigurationException.class,
+                                () -> LaunchConfiguration.parse(new String[] { "--unknown" }));
+
+                assertTrue(exception.getMessage().contains("Unrecognized option"));
+                assertNotNull(exception.getHelpText());
+                assertFalse(exception.getHelpText().isBlank());
+        }
+}


### PR DESCRIPTION
## Summary
- replace direct JVM exits in `LaunchConfiguration` with `InvalidLaunchConfigurationException`
- catch the new exception in `JMediaOrganizer.main`, log the message, print the CLI help text, and exit with a failure status
- add unit tests covering invalid CLI argument scenarios that now raise exceptions

## Testing
- mvn -q test *(fails: blocked from downloading Maven plugins in the execution environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690dd40d878c8328a085193a8a2388df)